### PR TITLE
fixed: create-abell-app not working in windows

### DIFF
--- a/bin/create-abell-app.js
+++ b/bin/create-abell-app.js
@@ -55,7 +55,7 @@ program
     } else {
       // Execute git clone
       console.log(`\n${colors.green('>')} Fetching Template from GitHub ✨\n\n`);
-      execSync(`git clone ${template} ${projectName}`, execOptions)
+      execSync(`git clone ${template} ${projectName}`)
     }
 
     // remove package-lock.json if preferred installer is yarn
@@ -74,6 +74,8 @@ program
     console.log(`\n${colors.green('>')} Finished Installing Dependencies 🤠`);
     console.log(`${colors.green('>')} Successfully Created ${projectName} 🚀`);
     console.log(`\n${colors.green('>>')} \`cd ${projectName}\` and \`${installCommand === 'yarn' ? 'yarn' : 'npm run'} dev\` to run dev-server ✨\n\n`);
+    // Exit
+    process.exit(-1);
   });
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-abell-app",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Changed
```js
execSync(`git clone ${template} ${projectName}`, execOptions)
```
to 
```js
execSync(`git clone ${template} ${projectName}`)
```
And added 
```js
process.exit(-1);
```
To automatically exit the script. 😄